### PR TITLE
Change the center of gravity for the image on the job offers page

### DIFF
--- a/app/assets/stylesheets/job_offers.scss
+++ b/app/assets/stylesheets/job_offers.scss
@@ -24,11 +24,12 @@ body.job-offer {
     .row-margin {
       .center-block {
         display: block;
-        margin-left: 175px;
-        margin-right: 238px;
+        margin-left: auto;
+        margin-right: auto;
       }
 
       img {
+        padding-right: 8%;
         width: 50%;
       }
       


### PR DESCRIPTION
Default aligment of image to center looks:
![oryginal-configuration for-center-block_](https://user-images.githubusercontent.com/76939215/118255733-e4be8d80-b4ac-11eb-8544-091c0fd0ad98.png)

The center of gravity for the image is move to right.

For better view we change css style.
Now it looks:
![with-padding-right-in-img_](https://user-images.githubusercontent.com/76939215/118256106-69a9a700-b4ad-11eb-9e95-0fa9c5df1337.png)

and also looks correct for mobile devices:
![with-padding-rigth-iPad_](https://user-images.githubusercontent.com/76939215/118256598-fa808280-b4ad-11eb-91d6-e1bef9813cbd.png)
![with-padding-right-Galaxy Fold_](https://user-images.githubusercontent.com/76939215/118256751-213eb900-b4ae-11eb-89ad-90c5258acca6.png)


