### PR TITLE
Fix off-grid logotypes

### DIFF
--- a/app/views/people/_technologies.slim
+++ b/app/views/people/_technologies.slim
@@ -7,9 +7,9 @@
       ul.list-inline
         - technologies.each do |technology|
           li
-          - if technology.any_image?
-              = image_tag technology.logotype_or_image_base64, alt: technology.name, title: technology.title, width: '64px'
-          - else
-            span.label.label-default
-              = technology.title
-          '
+            - if technology.any_image?
+                = image_tag technology.logotype_or_image_base64, alt: technology.name, title: technology.title, width: '64px'
+            - else
+              span.label.label-default
+                = technology.title
+            '


### PR DESCRIPTION
## Pull Request Summary

I noticed that in the list of technologies, when the second row appears (minimum 5 elements) the logotypes are not evenly in the grid. It turned out that the indentation was missing and the image was next to the list item, not inside it.

## UI Changes

### Before

![before](https://user-images.githubusercontent.com/76075/220979085-00c4b25c-c23a-4368-8176-842628eb37a2.png)

### After

![after](https://user-images.githubusercontent.com/76075/220979118-3bc02205-1643-402d-9030-4c534a34f6fe.png)
