### PR TITLE
Embedded SVG

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'jquery-turbolinks'
 gem 'mail_form'
 gem 'meta-tags' # Search Engine Optimization (SEO) for Rails
 gem 'mini_magick', '~> 4.12', platform: :ruby
+gem 'nokogiri'
 gem 'normalize-rails', '~> 8.0.1'
 gem 'oj' # Fast JSON parser and object serializer
 gem 'pg' # Ruby interface to PostgreSQL RDBMS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -557,6 +557,7 @@ DEPENDENCIES
   mail_form
   meta-tags
   mini_magick (~> 4.12)
+  nokogiri
   normalize-rails (~> 8.0.1)
   oj
   pg

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,4 +3,16 @@ module ApplicationHelper
   def default_meta_tags
     I18n.t(:meta).merge(separator: '|', author: '/humans.txt', reverse: true)
   end
+
+  # rubocop:disable Rails/OutputSafety
+  def embedded_svg(svg_body, options: {}, title: nil)
+    doc = Nokogiri::HTML::DocumentFragment.parse(svg_body)
+    svg = doc.at_css 'svg'
+
+    svg.add_child("<title>#{title}</title>") if title
+    options.each { |attribute, value| svg[attribute.to_s] = value }
+
+    doc.to_html.html_safe
+  end
+  # rubocop:enable Rails/OutputSafety
 end

--- a/app/models/technology.rb
+++ b/app/models/technology.rb
@@ -18,7 +18,7 @@ class Technology < ApplicationRecord
   scope :sorted, -> { order(position: :asc) }
 
   def any_image?
-    !(icon_wordmark || icon).nil?
+    logotype_or_image.present?
   end
 
   def image_base64
@@ -31,6 +31,10 @@ class Technology < ApplicationRecord
     return unless icon_wordmark
 
     svg_to_base64(icon_wordmark)
+  end
+
+  def logotype_or_image
+    icon_wordmark || icon
   end
 
   def logotype_or_image_base64

--- a/app/views/people/_technologies.slim
+++ b/app/views/people/_technologies.slim
@@ -8,6 +8,7 @@
         - technologies.each do |technology|
           li
             - if technology.any_image?
+                / = embedded_svg(technology.logotype_or_image, options: { height: '64px', width: '64px' }, title: technology.title)
                 = image_tag technology.logotype_or_image_base64, alt: technology.name, title: technology.title, width: '64px'
             - else
               span.label.label-default


### PR DESCRIPTION
## Pull Request Summary

We have some graphics in the form of SVG files. This is especially used on the show of person. We know more and more technologies, therefore each technology is a separate icon to be loaded.

Instead of making multiple requests, we can embed these SVG files into the page. This will also allow us to cache this dynamic page as a static page.

So I present an initial implementation of embedded SVG.

## Feedback

Known issues:
- some SVGs are of unusual size (sqlite.svg, unity3d-original.svg, leaflet-wordmark.svg, marionettejs.svg, jekyll-wordmark.svg, playwright.svg, sidekiq.svg)
![sqlite](https://user-images.githubusercontent.com/76075/221157076-50a36215-fb47-4eb6-9806-c33094318b36.png)
![marionette](https://user-images.githubusercontent.com/76075/221157310-65e65b38-6761-4ac4-a4e4-a1ef05ec7c02.png)
![sidekiq](https://user-images.githubusercontent.com/76075/221157579-69fb62a0-d96a-4e4a-9699-80780e5cabf9.png)

- some weird borders on the sides of the SVG (postgis.svg) - IMO another SVG file would be useful 
![postgis](https://user-images.githubusercontent.com/76075/221156804-2efde5db-789a-406e-83a2-d4a33acd2728.png)

- some SVG's use gradients and the id is the same, causing the colors of other icons to change

Ruby SVG:

```svg
<linearGradient id="a" gradientUnits="userSpaceOnUse" x1="143.917" y1="2125.439" x2="125.854" y2="2157.331" gradientTransform="matrix(1 0 0 -1 -47.5 2221)"><stop offset="0" stop-color="#FB7655"></stop><stop offset="0" stop-color="#FB7655"></stop><stop offset=".41" stop-color="#E42B1E"></stop><stop offset=".99" stop-color="#900"></stop><stop offset="1" stop-color="#900"></stop></linearGradient>

<path fill="url(#a)" d="M87.524 58.767L38.638 87.795l63.3-4.294 4.875-63.828z"></path>
```

![ruby](https://user-images.githubusercontent.com/76075/221154746-c7d1b486-d324-4a95-8d49-67a2b31a7936.png)


Python SVG:

```svg
<linearGradient id="a" gradientUnits="userSpaceOnUse" x1="54.862" y1="755.717" x2="85.342" y2="729.493" gradientTransform="matrix(.563 0 0 -.568 -29.215 475.753)"><stop offset="0" stop-color="#5A9FD4"></stop><stop offset="1" stop-color="#306998"></stop></linearGradient>

<path fill="url(#a)" d="M17.761 45.612c-1.282.007-2.505.116-3.583.307-3.172.561-3.748 1.734-3.748 3.896v2.857h7.496v.952h-10.309000000000001c-2.179 0-4.086 1.31-4.683 3.8-.688 2.856-.719 4.639 0 7.619.533 2.219 1.805 3.801 3.984 3.801h2.577v-3.424c0-2.475 2.141-4.657 4.683-4.657h7.488c2.084 0 3.748-1.717 3.748-3.809v-7.139c0-2.031-1.714-3.558-3.748-3.896-1.288-.214-2.624-.312-3.905-.307zm-4.054 2.299c.774 0 1.407.643 1.407 1.433 0 .787-.632 1.425-1.407 1.425-.777 0-1.406-.638-1.406-1.425-.001-.79.629-1.433 1.406-1.433z"></path>
```

![python](https://user-images.githubusercontent.com/76075/221154900-a8021c70-7335-487a-b5f0-97859f7d982a.png)


Cordova SVG:

```svg
<linearGradient xlink:href="#a" id="h" x1="386.671" y1="402.394" x2="70.076" y2="198.421" gradientUnits="userSpaceOnUse" gradientTransform="translate(-14.85 -10.607)"></linearGradient>
```

![cordova](https://user-images.githubusercontent.com/76075/221155282-fe38d25a-c3d0-481d-b720-39e493a8c496.png)


Linux SVG

```svg
<radialGradient id="a" cx="-992.915" cy="-952.952" r="43.267" gradientTransform="matrix(.7 0 0 .35 782.303 444.575)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-opacity=".502"></stop><stop offset="1" stop-opacity="0"></stop></radialGradient>

<path fill="url(#a)" d="M117.641 111.137c0 8.362-13.557 15.14-30.28 15.14-16.722 0-30.279-6.778-30.279-15.14s13.556-15.14 30.278-15.14c16.723.001 30.281 6.779 30.281 15.14z"></path>
```

![linux](https://user-images.githubusercontent.com/76075/221155895-34b144f1-fd29-4b52-96e1-8cf1c2dba8e8.png)
