### PR TITLE
Remove npm dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,11 +14,3 @@ updates:
       - dependency-type: "development"
     ignore:
       - dependency-name: "rails"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: monthly
-      time: "12:00"
-    labels:
-      - dependencies
-      - javascript


### PR DESCRIPTION
## Pull Request Summary

Since we swapped from using webpacker, npm and yarn we no longer keep our dependencies in npm/yarn. Since this part of dependabot won't be able to check our packeges we no longer need it.
