### PR TITLE
Redesign of team view

### DIFF
--- a/app/assets/stylesheets/home.scss.erb
+++ b/app/assets/stylesheets/home.scss.erb
@@ -112,7 +112,7 @@ body.home {
 
   .technology {
     background-color: $light-background-color;
-    @include vertical-padding(20px);
+    @include vertical-padding(120px);
     text-align: center;
 
     .btn.btn-default {

--- a/app/assets/stylesheets/people.scss
+++ b/app/assets/stylesheets/people.scss
@@ -86,20 +86,10 @@ body.person {
 }
 
 .team {
-  padding-bottom: 100px;
-  text-align: center;
-
   h2 {
     @include vertical-padding(60px);
     font-weight: 700;
     text-transform: uppercase;
-  }
-
-  a {
-    color: $grey-text-color;
-    text-decoration: none;
-
-    &:hover { color: $red-background-color; }
   }
 
   .person-card {

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -31,8 +31,12 @@ class PersonDecorator < Draper::Decorator
     end
   end
 
+  def first_name
+    object.fullname.split.first
+  end
+
   def image
-    image_tag object.image, alt: '', class: 'rounded', size: '256x256'
+    image_tag object.image, alt: '', class: 'rounded-circle', size: '256x256'
   end
 
   def introduction

--- a/app/views/home/index.slim
+++ b/app/views/home/index.slim
@@ -40,10 +40,6 @@
 
   = render 'people/team', people: @home.people, cached: true
 
-  br
-  br
-  br
-
   .container.technology.hidden-xs
     .row
       .col-sm-10.offset-md-1

--- a/app/views/home/index.slim
+++ b/app/views/home/index.slim
@@ -40,6 +40,10 @@
 
   = render 'people/team', people: @home.people, cached: true
 
+  br
+  br
+  br
+
   .container.technology.hidden-xs
     .row
       .col-sm-10.offset-md-1

--- a/app/views/people/_person.slim
+++ b/app/views/people/_person.slim
@@ -1,14 +1,19 @@
-.col-md-6.col-sm-12.g-3
-  .img-thumbnail.position-relative.h-100.pb-3.d-flex.flex-column.justify-content-between.person-card
-    = link_to person_path(id: person), class: "stretched-link" do
+.col
+  .card.h-100.text-center.border-0
+    .card-img-top
       = person.image
-      h3
-        = person.fullname
-      p.text-center
-        = person.introduction
-    ul.d-inline.social
-      = person.blog
-      = person.github
-      = person.linkedin
-      = person.twitter
-      = person.website
+    .card-header.bg-transparent
+      h3.card-title
+        = person.first_name
+    .card-body
+      p.card-text
+        == person.introduction
+      p
+        = link_to t('.person.see_full_profile'), person_path(id: person), class: 'btn btn-outline-dark btn-sm'
+    .card-footer.bg-transparent
+      ul.d-inline.social
+        = person.blog
+        = person.github
+        = person.linkedin
+        = person.twitter
+        = person.website

--- a/app/views/people/_team.slim
+++ b/app/views/people/_team.slim
@@ -1,6 +1,8 @@
 - cache people do
   .container.team
-    h2
-      = t('.team.meet_us')
     .row
+      .col-md-10.offset-md-1
+        h2.text-center
+          = t('.team.meet_us')
+    .row.row-cols-1.row-cols-md-2.g-5
       = render people

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,6 +88,9 @@ en:
       card: summary
       site: "@fractal_soft"
   people:
+    person:
+      person:
+        see_full_profile: See full profile
     project:
       major_contributions: Major contributions
     skills:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -88,6 +88,9 @@ pl:
       card: summary
       site: "@fractal_soft"
   people:
+    person:
+      person:
+        see_full_profile: Zobacz pełny profil
     project:
       major_contributions: Znaczący wkład
     skills:


### PR DESCRIPTION
## Pull Request Summary

I changed the previous structure and I used Bootstrap's [card component](https://getbootstrap.com/docs/5.3/components/card/). I was also inspired by the example with [carousel](https://getbootstrap.com/docs/5.3/examples/carousel/) from Bootstrap.

I initially wanted to use something similar to examples from a [blog](https://getbootstrap.com/docs/5.3/examples/blog/) or [album](https://getbootstrap.com/docs/5.3/examples/album/), but in our case we have profile pictures, not images that we can crop freely.

## Description of the Changes

In general, I wanted to simplify the structure and use ready-made elements from Bootstrap. Secondly, I want the look to be a little more modern.

Step by step I also reduced our CSS lines.

## Feedback

I had to temporarily add ~some blank lines~ padding on the homepage to move the container below. I will remove them in the next revisions when I rework this part.

## UI Changes

### Desktop

#### Before

![before-desktop](https://user-images.githubusercontent.com/76075/231803410-2ce72975-1353-4e4c-a6e4-3e5591d7cc78.png)

#### After

![after-desktop](https://user-images.githubusercontent.com/76075/231802793-a66ff1f8-20b7-47ad-b3e9-496f3689a536.png)

----

### Mobile

#### Before

![before-mobile](https://user-images.githubusercontent.com/76075/231803234-c6f8acb1-f126-4135-913d-e23ccd605938.png)

#### After

![after-mobile](https://user-images.githubusercontent.com/76075/231802888-498b1d23-6949-4842-a6b4-64e3a74c16ec.png)
