### PR TITLE
Remove versioning strategy on CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
       - dependency-type: "all"
     ignore:
       - dependency-name: "rails"
-    versioning-strategy: increase-if-necessary
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -28,4 +27,3 @@ updates:
       day: thursday
       interval: weekly
       time: "09:00"
-    versioning-strategy: auto


### PR DESCRIPTION
## Pull Request Summary

After merging PR #245 we got the following warning:

> Dependabot encountered the following error when parsing your .github/dependabot.yml:
>
> The property '#/updates/1/' contains additional properties ["versioning-strategy"] outside of the schema when none are allowed
> Please update the config file to conform with Dependabot's specification.

I removed [versioning-strategy](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy) from [dependabot configuration](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-dependabotyml) to get rid of the problem.
We will use the default settings. This works for our other projects, so I assume the problem will go away.

## Feedback

Source of problem: https://github.com/fractalsoft/fractalsoft.org/runs/16263571645

## UI Changes

N/A
