### PR TITLE
Remove the duplication from importmap

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -11,10 +11,9 @@ pin "picocolors", to: "https://ga.jspm.io/npm:picocolors@1.0.0/picocolors.browse
 pin "process", to: "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/process-production.js"
 pin "source-map-js", to: "https://ga.jspm.io/npm:source-map-js@1.0.2/source-map.js"
 pin "url", to: "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/url.js"
-pin "jquery", to: "https://ga.jspm.io/npm:jquery@3.6.4/dist/jquery.js"
+pin "jquery", to: "https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js", preload: true
 pin "bootstrap", to: "bootstrap.min.js", preload: true
 pin "@popperjs/core", to: "popper.js", preload: true
-pin "jquery", to: "https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.js"
 pin "@rails/ujs", to: "https://ga.jspm.io/npm:@rails/ujs@7.0.1/lib/assets/compiled/rails-ujs.js"
 pin "turbolinks", to: "https://ga.jspm.io/npm:turbolinks@5.2.0/dist/turbolinks.js"
 pin "@rails/activestorage", to: "https://ga.jspm.io/npm:@rails/activestorage@7.0.4-3/app/assets/javascripts/activestorage.esm.js"


### PR DESCRIPTION
## Pull Request Summary

In our importmap setup, we pinned jquery twice. This didn't cause any error, however it can be confusing as we were using two different jquery versions.

## Description of the Changes

I removed the older version of the pinned library.

## Feedback

N/A

## UI Changes

N/A
