### PR TITLE
Replace Image Magick with vips

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV RAILS_ENV="production" \
 # Throw-away build stage to reduce size of final image
 FROM base as build
 
-ARG BUILD_PACKAGES="build-essential git imagemagick pkg-config libpq-dev curl python-is-python3"
+ARG BUILD_PACKAGES="build-essential git libvips42 pkg-config libpq-dev curl python-is-python3"
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
@@ -48,7 +48,7 @@ RUN SECRET_KEY_BASE=DUMMY bundle exec rails assets:precompile
 # Final stage for app image
 FROM base
 
-ARG DEPLOY_PACKAGES="build-essential git imagemagick pkg-config libpq-dev curl python-is-python3 postgresql-client"
+ARG DEPLOY_PACKAGES="build-essential git libvips42 pkg-config libpq-dev curl python-is-python3 postgresql-client"
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'importmap-rails', '~> 1.2'
 gem 'jbuilder', '~> 2.11'
 gem 'mail_form'
 gem 'meta-tags' # Search Engine Optimization (SEO) for Rails
-gem 'mini_magick', '~> 4.12', platform: :ruby
 gem 'mini_racer'
 gem 'nokogiri'
 gem 'normalize-rails', '~> 8.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -557,7 +557,6 @@ DEPENDENCIES
   listen
   mail_form
   meta-tags
-  mini_magick (~> 4.12)
   mini_racer
   nokogiri
   normalize-rails (~> 8.0.1)

--- a/app/uploaders/community_logo_uploader.rb
+++ b/app/uploaders/community_logo_uploader.rb
@@ -1,5 +1,5 @@
 class CommunityLogoUploader < ImageUploader
-  process resize_to_minimum_fill: [256]
+  process resize_to_fit: [256, 256]
   process convert: 'png'
 
   protected

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,5 +1,7 @@
+require 'carrierwave/processing/vips'
+
 class ImageUploader < CarrierWave::Uploader::Base
-  include CarrierWave::MiniMagick
+  include CarrierWave::Vips
 
   storage :file
   # storage :fog

--- a/db/seeds/community/coderdojo.rb
+++ b/db/seeds/community/coderdojo.rb
@@ -9,7 +9,7 @@ coderdojo_meeting_in_twenty_fifteen = youtube_iframe(coderdojo_meeting_in_twenty
 coderdojo_santa_claus_in_twenty_fifteen = youtube_iframe(coderdojo_santa_claus_in_twenty_fifteen_youtube_url)
 coderdojo_preparing_coolest_project = vimeo_iframe(coderdojo_preparing_coolest_project_vimeo_url)
 
-coderdojo_logo = File.new('db/seeds/community/coderdojo/coderdojo-logo.png')
+# coderdojo_logo = File.new('db/seeds/community/coderdojo/coderdojo-logo.png')
 coderdojo_logotype = File.new('db/seeds/community/coderdojo/coderdojo-logotype.png')
 
 coderdojo.assign_attributes(
@@ -87,4 +87,4 @@ coderdojo.title = 'Nauka programowania dla dzieci i młodzieży - CoderDojo'
 
 coderdojo.save
 
-coderdojo.update(logo: coderdojo_logo, logotype: coderdojo_logotype)
+coderdojo.update(logo: coderdojo_logotype, logotype: coderdojo_logotype)


### PR DESCRIPTION
## Pull Request Summary

I replaced [ImageMagick](https://imagemagick.org/) with [libvips](https://www.libvips.org/) to reduce memory consumption in production.

## Feedback

I believed that the Docker image after build also should be smaller. The app seems to be using less memory, but the Docker image is bigger. This is a bit confusing for me.

```
REPOSITORY                  TAG       IMAGE ID       CREATED             SIZE
vips                        latest    14c4a2ee229d   About an hour ago   916MB
image-magick                latest    6e830d39ccf3   2 hours ago         871MB
```

## UI Changes

N/A
