### PR TITLE
Remove `webdrivers` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,6 @@ group :test do
   gem 'database_cleaner', '~> 2.0.1'
   gem 'factory_bot_rails'
   gem 'shoulda-matchers'
-  gem 'webdrivers' # Web drivers to run system tests with browsers
 end
 
 gem 'dockerfile-rails', '>= 1.5', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -514,10 +514,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -589,7 +585,6 @@ DEPENDENCIES
   stackprof
   tzinfo-data
   web-console (>= 4.2)
-  webdrivers
 
 RUBY VERSION
    ruby 3.2.2p53


### PR DESCRIPTION
## Pull Request Summary

There is a dependency between updating `webdrivers` to version 5.3.1  and updating `selenium-webdriver` to version 4.12.0.
Updating `webdrivers` to the latest version will result in a  lower `selenium-webdriver` version.
Updating `selenium-webdriver` to the latest version will result in a lower `webdrivers` version.
The `dependabot` will open a new PR to update one gem, and then open another PR to update the other gem, and so on.

## Description of the Changes

Now `Selenium` itself manages drivers by default, so we can remove the `webdrives` gem.

## Feedback

N/A

## UI Changes

N/A
