### PR TITLE
Team member image as a link

### DIFF
--- a/app/views/people/_person.slim
+++ b/app/views/people/_person.slim
@@ -1,7 +1,8 @@
 .col
   .card.h-100.text-center.border-0
     .card-img-top
-      = person.image
+      = link_to person_path(id: person) do
+        = person.image
     .card-header.bg-transparent
       h3.card-title
         = person.first_name


### PR DESCRIPTION
## Pull Request Summary

On the Fractal Soft team page we have pictures of each team member. We want these pictures
to also be a link to that person's description page.

## Feedback

N/A

## UI Changes

N/A
