### PR TITLE
Fix behavior of bootstrap accordion

### DIFF
--- a/app/views/people/show.slim
+++ b/app/views/people/show.slim
@@ -24,7 +24,7 @@
     .accordion
       .accordion-item
         h2.accordion-header
-          button.accordion-button type='button' data-bs-toggle='collapse' data-bs-target="#collapse-project-#{project.slug}" aria-expanded='true' aria-controls="collapse-project-#{project.slug}"
+          button.accordion-button type='button' data-bs-toggle='collapse' data-bs-target="#collapse-project-#{project.slug}" aria-expanded='true' aria-controls="collapse-project-#{project.slug}" class="#{index >= 2 ? 'collapsed' : ''}"
             = project.title
         .accordion-collapse.collapse aria-labelledby='projectListHeader' id="collapse-project-#{project.slug}" class="#{index < 2 ? 'show' : ''}"
           .accordion-body
@@ -36,7 +36,7 @@
     .accordion
       .accordion-item
         h2.accordion-header
-          button.accordion-button type='button' data-bs-toggle='collapse' data-bs-target="#collapseTechnologyList" aria-expanded='true' aria-controls='collapseTechnologyList'
+          button.accordion-button.collapsed type='button' data-bs-toggle='collapse' data-bs-target="#collapseTechnologyList" aria-expanded='true' aria-controls='collapseTechnologyList'
             = t('.see_more_technology')
         #collapseTechnologyList.accordion-collapse.collapse aria-labelledby='technologyListHeader'
           .accordion-body


### PR DESCRIPTION
## Pull Request Summary

The Bootstrap's component - accordion is used on each team member's page. It has the same settings for open accordion item and for closed accordion items.
Closed accordion items should have a different background color and arrow direction than open ones.

## Description of the Changes

Accordion items must be marked as `collapsed` to be displayed on the page with the closed accordion item settings.

## Feedback

N/A

## UI Changes

### Before

![before-accordion-items](https://github.com/fractalsoft/fractalsoft.org/assets/76939215/5caea133-cd70-4a71-8901-da2956bbe59f)

### After

![after-accordion-items](https://github.com/fractalsoft/fractalsoft.org/assets/76939215/8232e531-f919-4e9f-9acf-2561f2e9a052)
