### PR TITLE
Fix typos in the profiles

### DIFF
--- a/app/models/technology.rb
+++ b/app/models/technology.rb
@@ -24,7 +24,7 @@ class Technology < ApplicationRecord
   friendly_id :slug, use: [:slugged, :finders]
   translates :description, :meta_description, :meta_title, :name, :title
 
-  scope :linters_and_code_formaters, -> { linter.or(code_formatter) }
+  scope :linters_and_code_formatters, -> { linter.or(code_formatter) }
   scope :sorted, -> { order(position: :asc) }
 
   def any_image?

--- a/app/views/people/_technologies_in_categories.slim
+++ b/app/views/people/_technologies_in_categories.slim
@@ -12,6 +12,6 @@
   = render 'technologies', category: :cloud_computing, person: @person
   = render 'technologies', category: :mathematical_software, person: @person
   = render 'technologies', category: :project_management_software, person: @person
-  = render 'technologies', category: :linters_and_code_formaters, person: @person
+  = render 'technologies', category: :linters_and_code_formatters, person: @person
   = render 'technologies', category: :continuous_integration, person: @person
   = render 'technologies', category: :amazon_web_services, person: @person

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,7 +107,7 @@ en:
       database: Databases
       frontend: Frontend development
       gamedev: Game development
-      linters_and_code_formaters: Linters & code_formaters
+      linters_and_code_formatters: Linters & code formatters
       mathematical_software: Mathematical software
       mobile: Mobile development
       operating_system: Operating systems

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -107,7 +107,7 @@ pl:
       database: Bazy danych
       frontend: Frontend development
       gamedev: Programowanie gier
-      linters_and_code_formaters: Lintery i formatery kodu
+      linters_and_code_formatters: Lintery i formatery kodu
       mathematical_software: Oprogramowanie matematyczne
       mobile: Mobile development
       operating_system: Systemy operacyjne


### PR DESCRIPTION
## Pull Request Summary

The English version of each team member's technology skills profile had typos in the title "Linters and code formatters". I fixed it.

## Feedback

N/A

## UI Changes

N/A
