### PR TITLE
Add an effect for member pictures

### DIFF
--- a/app/assets/stylesheets/people.scss
+++ b/app/assets/stylesheets/people.scss
@@ -109,3 +109,16 @@ body.person {
     position: relative;
   }
 }
+
+.member-picture img {
+  box-shadow: 0 0 4px 4px $light-grey-background-color;
+  transition: 1s ease-in-out;
+  transform: scale(0.9);
+
+  &:hover {
+    box-shadow: 0 0 0 0;
+    filter: brightness(110%);
+    transition: 1s ease-in-out;
+    transform: scale(0.95);
+  }
+}

--- a/app/views/people/_person.slim
+++ b/app/views/people/_person.slim
@@ -1,6 +1,6 @@
 .col
   .card.h-100.text-center.border-0
-    .card-img-top
+    .card-img-top.member-picture
       = link_to person_path(id: person) do
         = person.image
     .card-header.bg-transparent


### PR DESCRIPTION
## Pull Request Summary

We want to the team member picture, which is a link to detailed page about the selected person, to encourage users to click on it, to be clearer to use.

## Description of the Changes

The appearance of the picture changes before and after the user hovers over the selected one. It has different size and colors.

## Feedback

N/A

## UI Changes

###

![before-hover](https://github.com/fractalsoft/fractalsoft.org/assets/76939215/eb6e0163-10bc-4fb9-b3a9-05e0ba691557)

###

![after-hover](https://github.com/fractalsoft/fractalsoft.org/assets/76939215/e6a01b17-a037-44ee-a6e4-2cb95f5a1bf9)

###

![hover-pictures](https://github.com/fractalsoft/fractalsoft.org/assets/76939215/0b0409a8-05e8-4ae5-bf06-c2402c7686de)
