### PR TITLE
Fix name of field in seeds

### DIFF
--- a/db/seeds/team/torrocus.rb
+++ b/db/seeds/team/torrocus.rb
@@ -1,6 +1,6 @@
 torrocus = Person.where(nickname: 'torrocus').first_or_initialize
 torrocus.assign_attributes(
-  blog: 'https://torrocus.com/blog/',
+  blog_url: 'https://torrocus.com/blog/',
   description: 'Ruby on Rails developer',
   facebook: 'torrocus',
   first_name: 'Alex',
@@ -15,7 +15,7 @@ torrocus.assign_attributes(
             Agile, Team Building, Linux Server Administration, Remote Work, Product Development
           ),
   twitter: 'torrocus',
-  website: 'https://torrocus.com'
+  website_url: 'https://torrocus.com'
 )
 
 I18n.locale = :en

--- a/db/seeds/team/womanonrails.rb
+++ b/db/seeds/team/womanonrails.rb
@@ -1,6 +1,6 @@
 womanonrails = Person.where(nickname: 'womanonrails').first_or_initialize
 womanonrails.assign_attributes(
-  blog: 'https://womanonrails.com',
+  blog_url: 'https://womanonrails.com',
   description: 'Ruby on Rails developer',
   facebook: 'womanonrails',
   first_name: 'Agnieszka',


### PR DESCRIPTION
## Pull Request Summary

 When we deploy the application to fly.io, we need to load seeds every time.
I'm getting information about aborted loading of seeds because of incompatibility name of fields during `rails db:seed`.

## Description of the Changes

Among other things, we changed the names of fields in the database for the person model. We changed blog to blog_url and website to website_url.
But we didn't change the names of the fields for assign_attributes in seeds. Making these changes should fix the problem.

## Feedback

N/A

## UI Changes

N/A
