### PR TITLE
Fix accordions behavior

### DIFF
--- a/app/views/people/show.slim
+++ b/app/views/people/show.slim
@@ -24,9 +24,9 @@
     .accordion
       .accordion-item
         h2.accordion-header
-          button.accordion-button type='button' data-bs-toggle='collapse' data-bs-target="#collapse-project-#{project.slug}" aria-expanded='true' aria-controls="collapse-project-#{project.slug}" class="#{index >= 2 ? 'collapsed' : ''}"
+          button.accordion-button type='button' data-bs-toggle='collapse' data-bs-target="#collapse-project-#{index}" aria-expanded='true' aria-controls="collapse-project-#{index}" class="#{index >= 2 ? 'collapsed' : ''}"
             = project.title
-        .accordion-collapse.collapse aria-labelledby='projectListHeader' id="collapse-project-#{project.slug}" class="#{index < 2 ? 'show' : ''}"
+        .accordion-collapse.collapse aria-labelledby='projectListHeader' id="collapse-project-#{index}" class="#{index < 2 ? 'show' : ''}"
           .accordion-body
             = render 'project', project: project, contributions: @person.project_with_contributions(project)
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -67,4 +67,22 @@ RSpec.describe Project do
       expect(project.top_image).to eq(image)
     end
   end
+
+  describe 'slug validation' do
+    context 'when slug does not contain a dot' do
+      it 'is validated correctly' do
+        project = build(:project, slug: 'slug-name-without-dot')
+
+        expect(project).to be_valid
+      end
+    end
+
+    context 'when slug contains a dot' do
+      it 'is also validated correctly' do
+        project = build(:project, slug: 'slug-name-with.dot')
+
+        expect(project).to be_valid
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Pull Request Summary

Recently we have noticed that some accordions are not behaving correctly. @ania-hm discovered that what makes them stand out is that their slug name of projects contain a dot. This allowed us to understand the cause of the problem. Adding a dot to the name meant that `data-bs-target` and `id` probably didn't match. We changed our views a bit because a slug containing a dot is valid.

## Feedback

N/A

## UI Changes

N/A
