### PR TITLE
Fix HtmlMinifier for empty chunk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,7 @@ AllCops:
 Metrics/MethodLength:
   CountComments: false
   Exclude:
+    - app/middleware/html_minifier.rb
     - app/uploaders/community_logo_uploader.rb
     - db/seeds/06_community.rb
   Max: 5

--- a/app/middleware/html_minifier.rb
+++ b/app/middleware/html_minifier.rb
@@ -33,6 +33,8 @@ class HtmlMinifier
 
   def compress(response)
     response.each do |chunk|
+      next if chunk.frozen?
+
       REGEXES.each do |regex, substitute|
         chunk.gsub! regex, substitute
       end

--- a/spec/middleware/html_minifier_spec.rb
+++ b/spec/middleware/html_minifier_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe HtmlMinifier do
+  context 'when rendering any HTML view' do
+    let(:body) do
+      [
+        "<p>join</p>\n<p>lines</p>",
+        '<p>unnecessary</p>    <p>spaces</p>',
+        '<p><!-- unnecessary comment -->important content</p>',
+        '<script>function log() { var e = 2.7; console.log(e); }</script>'
+      ]
+    end
+    let(:expected) do
+      [
+        '<p>join</p><p>lines</p>',
+        '<p>unnecessary</p><p>spaces</p>',
+        '<p>important content</p>',
+        '<script>function log() {var e = 2.7;console.log(e);}</script>'
+      ]
+    end
+
+    it 'returns minified HTML without changing the content' do
+      app = ->(_) { [200, { 'Content-Type' => 'text/html' }, body] }
+      html_minifier = described_class.new(app)
+
+      expect(html_minifier.call({}).last).to eq(expected)
+    end
+  end
+
+  context 'when redirecting' do
+    let(:body) { [''.freeze] }
+    let(:expected) { body }
+
+    it 'returns the empty chunk unchanged' do
+      app = ->(_) { [302, { 'Content-Type' => 'text/html' }, body] }
+      html_minifier = described_class.new(app)
+
+      expect(html_minifier.call({}).last).to eq(expected)
+    end
+  end
+
+  context 'when rendering non-HTML view' do
+    let(:body) { ["lorem\nipsum"] }
+    let(:expected) { body }
+
+    it 'returns the original content unchanged' do
+      app = ->(_) { [200, { 'Content-Type' => 'text/plain' }, body] }
+      html_minifier = described_class.new(app)
+
+      expect(html_minifier.call({}).last).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
## Pull Request Summary

Recent changes have disrupted proper redirections in production, likely due to the stricter handling of frozen strings introduced in the Rails 7.1 release. Previously, Rails might not have set frozen strings for responses in redirects, but it's happening now and causing a 500 status.

## Description of the Changes

The root cause was identified in the `HtmlMinifier` middleware, responsible for content size reduction. Specifically, during redirection, the content is an empty, frozen string, leading to the issue. To address this, the modification now checks whether the chunk is frozen before proceeding. Additionally, comprehensive tests have been added to ensure the problem is permanently resolved.

## Feedback

N/A

## UI Changes

N/A
