### PR TITLE
Improve UX while using the contact form

### DIFF
--- a/app/controllers/contact_forms_controller.rb
+++ b/app/controllers/contact_forms_controller.rb
@@ -6,7 +6,7 @@ class ContactFormsController < ApplicationController
   def create
     @contact_form = ContactForm.new(params[:contact_form])
     @contact_form.request = request
-    @contact_form.deliver
-    redirect_to root_path
+    @contact_form.deliver ? flash[:notice] = t('.success') : flash[:alert] = t('.fail')
+    redirect_to "#{@contact_form.request.referrer}#contact"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,4 +13,11 @@ module ApplicationHelper
 
     doc.to_html.html_safe
   end
+
+  def flash_class(flash_type)
+    {
+      alert: 'danger',
+      notice: 'success'
+    }[flash_type.to_sym]
+  end
 end

--- a/app/views/contact_forms/_form.slim
+++ b/app/views/contact_forms/_form.slim
@@ -1,3 +1,6 @@
+- flash.each do |type, message|
+  p class="alert alert-#{flash_class(type)}" role='alert'
+    = message
 = simple_form_for contact_form, html: { id: 'contact_form' } do |f|
   = f.input :name, label: false, placeholder: t('.name'), required: true
   .d-none
@@ -6,6 +9,6 @@
   = f.input :message, label: false, placeholder: t('.message'), required: true, as: :text, input_html: { rows: 10 }
   = f.hidden_field :browser_info, value: ''
   .form-group
-    .row
+    .row.mb-3
       .col-sm-5.col-xs-12
         = f.submit t('.send'), class: 'btn btn-primary btn-block submit'

--- a/app/views/contact_forms/new.slim
+++ b/app/views/contact_forms/new.slim
@@ -17,6 +17,6 @@
           - class_name = (office_address.position == 1) ? 'active' : ''
           .btn.btn-default.btn-map class="#{class_name}" data-target="#{office_address.slug}-map"
             = office_address.name
-    .row
+    #contact.row
       .col-md-5.offset-md-4
         = render 'form', contact_form: @contact_form

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,9 @@ en:
   contact_forms:
     contact:
       contact_with_us: Contact with us
+    create:
+      fail: Unfortunately, something went wrong. The message has not been sent.
+      success: Thank you for Your message. We will reply as soon as possible.
     form:
       email: Your email address
       message: What we can do for you?

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -7,6 +7,9 @@ pl:
   contact_forms:
     contact:
       contact_with_us: Napisz do nas
+    create:
+      fail: Niestety coś poszło nie tak. Wiadomość nie została wysłana.
+      success: Dziękuję za Twoją wiadomość. Odpowiemy tak szybko, jak to możliwe.
     form:
       email: Twój adres email
       message: Jak możemy Ci pomóc?

--- a/spec/controllers/contact_forms_controller_spec.rb
+++ b/spec/controllers/contact_forms_controller_spec.rb
@@ -2,28 +2,114 @@ require 'rails_helper'
 
 RSpec.describe ContactFormsController do
   describe 'POST #create' do
-    let(:locale) { 'en' }
-    let(:params) do
-      { name: rand_text, email: 'test@example.com', message: rand_text }
+    context 'when English is used' do
+      let(:locale) { 'en' }
+      let(:params) do
+        { name: rand_text, email: 'test@example.com', message: rand_text }
+      end
+
+      before do
+        allow_any_instance_of(ContactForm).to receive(:deliver).and_return(nil)
+      end
+
+      it 'has ContactForm object' do
+        post :create, params: { contact_form: params, locale: }
+
+        expect(assigns(:contact_form)).to be_a(ContactForm)
+      end
+
+      it 'send mail to application owner' do
+        expect_any_instance_of(ContactForm).to receive(:deliver)
+
+        post :create, params: { contact_form: params, locale: }
+      end
+
+      it 'stays in the contact section of the home page after sending an email from the home page' do
+        allow_any_instance_of(ActionController::TestRequest).to receive(:referrer).and_return(root_path)
+        post :create, params: { contact_form: params, locale: }
+
+        expect(response).to redirect_to(root_path(locale:, anchor: 'contact'))
+      end
+
+      it 'stays on the contact page after sending an email from the contact page' do
+        allow_any_instance_of(ActionController::TestRequest).to receive(:referrer).and_return(new_contact_form_path)
+        post :create, params: { contact_form: params, locale: }
+
+        expect(response).to redirect_to(new_contact_form_path(locale:, anchor: 'contact'))
+      end
+
+      it 'displays a success message when an email has been sent' do
+        allow_any_instance_of(ContactForm).to receive(:deliver).and_return(true)
+        post :create, params: { contact_form: params, locale: }
+
+        expect(flash[:notice]).to eq(I18n.t('contact_forms.create.success'))
+      end
+
+      it 'displays a failed message when an email has failed to be sent' do
+        allow_any_instance_of(ContactForm).to receive(:deliver).and_return(false)
+        post :create, params: { contact_form: params, locale: }
+
+        expect(flash[:alert]).to eq(I18n.t('contact_forms.create.fail'))
+      end
     end
 
-    before do
-      allow_any_instance_of(ContactForm).to receive(:deliver).and_return(nil)
-    end
+    context 'when Polish is used' do
+      let(:locale) { 'pl' }
+      let(:params) do
+        { name: rand_text, email: 'test@example.com', message: rand_text }
+      end
 
-    it 'has ContactForm object' do
-      post :create, params: { contact_form: params, locale: }
-      expect(assigns(:contact_form)).to be_a(ContactForm)
-    end
+      before do
+        allow_any_instance_of(ContactForm).to receive(:deliver).and_return(nil)
+      end
 
-    it 'send mail to application owner' do
-      expect_any_instance_of(ContactForm).to receive(:deliver)
-      post :create, params: { contact_form: params, locale: }
-    end
+      it 'has ContactForm object' do
+        post :create, params: { contact_form: params, locale: }
 
-    it 'redirect back to main page' do
-      post :create, params: { contact_form: params, locale: }
-      expect(response).to redirect_to(root_en_path)
+        expect(assigns(:contact_form)).to be_a(ContactForm)
+      end
+
+      it 'send mail to application owner' do
+        expect_any_instance_of(ContactForm).to receive(:deliver)
+
+        post :create, params: { contact_form: params, locale: }
+      end
+
+      it 'stays in the contact section of the home page after sending an email from the home page' do
+        I18n.with_locale(:pl) do
+          allow_any_instance_of(ActionController::TestRequest).to receive(:referrer).and_return(root_path(locale:))
+          post :create, params: { contact_form: params, locale: }
+
+          expect(response).to redirect_to(root_path(locale:, anchor: 'contact'))
+        end
+      end
+
+      it 'stays on the contact page after sending an email from the contact page' do
+        I18n.with_locale(:pl) do
+          allow_any_instance_of(ActionController::TestRequest).to receive(:referrer).and_return(new_contact_form_path)
+          post :create, params: { contact_form: params, locale: }
+
+          expect(response).to redirect_to(new_contact_form_path(locale:, anchor: 'contact'))
+        end
+      end
+
+      it 'displays a success message when an email has been sent' do
+        I18n.with_locale(:pl) do
+          allow_any_instance_of(ContactForm).to receive(:deliver).and_return(true)
+          post :create, params: { contact_form: params, locale: }
+
+          expect(flash[:notice]).to eq(I18n.t('contact_forms.create.success'))
+        end
+      end
+
+      it 'displays a failed message when an email has failed to be sent' do
+        I18n.with_locale(:pl) do
+          allow_any_instance_of(ContactForm).to receive(:deliver).and_return(false)
+          post :create, params: { contact_form: params, locale: }
+
+          expect(flash[:alert]).to eq(I18n.t('contact_forms.create.fail'))
+        end
+      end
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper do
+  describe '#flash_class' do
+    context 'when flash type is notice' do
+      it 'returns success' do
+        expect(flash_class('notice')).to eq('success')
+      end
+    end
+
+    context 'when flash type is alert' do
+      it 'returns danger' do
+        expect(flash_class('alert')).to eq('danger')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Pull Request Summary

The current behavior of sending an email is confusing for the user.
When the user clicks the button to send an email, he is redirected to the home page without any information.
This happens both when he sends an email from the Contact Us section of the home page and when he sends an email from the contact page.
The user doesn't know what happened.
We want the user to see correct information about the result of sending an email, it means sending is successful or failure.
This information should be displayed on the same page from which the user sends an email. 

## Description of the Changes

Now the user knows if his message has been sent or not by seeing the correct message. The user still stays in the same place on the page where he sends an email.

## Feedback

N/A

## UI Changes

N/A
