### PR TITLE
Fix display of a team member card

### DIFF
--- a/app/assets/stylesheets/people.scss
+++ b/app/assets/stylesheets/people.scss
@@ -102,8 +102,6 @@ body.person {
     }
   }
 
-  .btn { margin-top: 50px; }
-
   .social-link {
     z-index: 10;
     position: relative;

--- a/app/views/people/_person.slim
+++ b/app/views/people/_person.slim
@@ -6,10 +6,10 @@
     .card-header.bg-transparent
       h3.card-title
         = person.first_name
-    .card-body
+    .card-body.d-flex.flex-column
       .card-text
         == person.introduction
-      p
+      p.mt-auto.pt-4
         = link_to t('.person.see_full_profile'), person_path(id: person), class: 'btn btn-outline-dark btn-sm'
     .card-footer.bg-transparent
       ul.list-group.list-group-horizontal.justify-content-center


### PR DESCRIPTION
## Pull Request Summary

On the main page of team members we have introduction for each person.
For each person is displayed his image, name, short introduction, button to the page with full information about this person and link to Github or social media. These data are organized inside bootstrap card.

Now we have defined a constant space between the short introduction and the button. This causes the button to have a different position depending on the size of the introduction.

It is visible because on the page the team members are displayed by two cards next to each other. This makes it look messy.

## Description of the Changes

I decided to remove our setting for the space between the introduction and the button and add a setting for the Bootstrap to correct the arrangement inside the person card.

## Feedback

N/A

## UI Changes

### Before

![before-team-page](https://github.com/fractalsoft/fractalsoft.org/assets/76939215/f03468cf-0613-4846-a670-e08869b60973)

### After

![after-team-page](https://github.com/fractalsoft/fractalsoft.org/assets/76939215/cf942657-015a-44d0-84d3-27ea924e8040)
