### PR TITLE
Improve contact form

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -3,7 +3,6 @@
 .btn {
   font-family: $asap-fonts;
   padding: 15px 50px;
-  text-transform: uppercase;
 
   &.btn-default {
     background-color: $white-background-color;

--- a/app/views/contact_forms/_form.slim
+++ b/app/views/contact_forms/_form.slim
@@ -2,11 +2,11 @@
   p class="alert alert-#{flash_class(type)}" role='alert'
     = message
 = simple_form_for contact_form, html: { id: 'contact_form' } do |f|
-  = f.input :name, label: false, placeholder: t('.name'), required: true
+  = f.input :name, placeholder: t('.name'), required: true
   .d-none
     = f.input :nickname, label: false, placeholder: t('.nickname.placeholder'), hint: t('.nickname.hint')
-  = f.input :email, label: false, placeholder: t('.email'), required: true
-  = f.input :message, label: false, placeholder: t('.message'), required: true, as: :text, input_html: { rows: 10 }
+  = f.input :email, placeholder: t('.email'), required: true
+  = f.input :message, placeholder: t('.message'), required: true, as: :text, input_html: { style: 'height: 240px' }
   = f.hidden_field :browser_info, value: ''
   .form-group
     .row.mb-3

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -46,7 +46,7 @@ SimpleForm.setup do |config|
   # vertical forms
   #
   # vertical default_wrapper
-  config.wrappers :vertical_form, class: 'mb-3' do |b|
+  config.wrappers :vertical_form, class: 'form-floating mb-3' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -54,8 +54,8 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label, class: 'form-label'
     b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label, class: 'form-label'
     b.use :full_error, wrap_with: { class: 'invalid-feedback' }
     b.use :hint, wrap_with: { class: 'form-text' }
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,7 +17,7 @@ en:
       nickname:
         hint: Leave this field blank!
         placeholder: Your nickname
-      send: send
+      send: Send message
     icons:
       find_us: You can also find us here
     new:
@@ -71,9 +71,9 @@ en:
   mail_form:
     attributes:
       contact_form:
-        email: E-mail
-        message: Sent message
-        name: Name
+        email: E-mail address
+        message: Message content
+        name: Your name
         nickname: Nickname
     models:
       contact_form: Fractal Soft - Your site contact form

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -17,7 +17,7 @@ pl:
       nickname:
         hint: Zostaw to pole puste!
         placeholder: Twój nick
-      send: wyślij
+      send: Wyślij wiadomość
     icons:
       find_us: Możesz nas znaleźć też tu
     new:
@@ -71,9 +71,9 @@ pl:
   mail_form:
     attributes:
       contact_form:
-        email: E-mail
-        message: Wysłana wiadomość
-        name: Imię
+        email: Adres e-mail
+        message: Treść wiadomości
+        name: Imię i nazwisko
         nickname: Nickname
     models:
       contact_form: Fractal Soft - Formularz kontaktowy z Twojej strony


### PR DESCRIPTION
## Pull Request Summary

Enable [floating labels](https://getbootstrap.com/docs/5.0/forms/floating-labels/) into our basic contact form.
Bootstrap has floating labels in the box, so we want to use this functionality.

## Feedback

N/A

## UI Changes

### Before

![before](https://github.com/fractalsoft/fractalsoft.org/assets/76075/4abf03cc-cbce-4fa0-9db0-8533de4c2317)

### After

![after](https://github.com/fractalsoft/fractalsoft.org/assets/76075/29c79297-31cc-4cf2-8070-361a0b0db855)
