### PR TITLE
Add a contact form for potential customers

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import 'normalize-rails';
 @import 'bootstrap';
 @import 'arts';
+@import 'business_contact_forms';
 @import 'common';
 @import 'community';
 @import 'contact_forms';

--- a/app/assets/stylesheets/business_contact_forms.scss
+++ b/app/assets/stylesheets/business_contact_forms.scss
@@ -1,0 +1,20 @@
+@import 'variables';
+@import 'mixins';
+
+body.business-contact-forms {
+  .container.contact {
+    background-color: $light-background-color;
+    margin-top: -250px;
+    min-height: 500px;
+  }
+
+  .footer {
+    margin-top: 0;
+  }
+}
+
+.background {
+  background-color: $red-background-color;
+  height: 350px;
+  margin-top: -20px;
+}

--- a/app/controllers/business_contact_forms_controller.rb
+++ b/app/controllers/business_contact_forms_controller.rb
@@ -1,2 +1,23 @@
 class BusinessContactFormsController < ApplicationController
+  before_action :set_business_contact_form, only: :create
+
+  def show; end
+
+  def new
+    @business_contact_form = BusinessContactForm.new
+  end
+
+  def create
+    if @business_contact_form.deliver
+      redirect_to business_contact_forms_path(locale: params[:locale])
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def set_business_contact_form
+    @business_contact_form = BusinessContactForm.new(params[:business_contact_form])
+  end
 end

--- a/app/controllers/business_contact_forms_controller.rb
+++ b/app/controllers/business_contact_forms_controller.rb
@@ -1,0 +1,2 @@
+class BusinessContactFormsController < ApplicationController
+end

--- a/app/models/business_contact_form.rb
+++ b/app/models/business_contact_form.rb
@@ -1,0 +1,20 @@
+class BusinessContactForm < MailForm::Base
+  include ActiveModel::Validations
+
+  attribute :attached_file, attachment: true
+  attribute :company_name
+  attribute :email, validate: true
+  attribute :first_name, validate: true
+  attribute :industry
+  attribute :last_name
+  attribute :message
+  attribute :need_nda
+  attribute :phone_number
+
+  def headers
+    {
+      from: Rails.application.secrets.noreply_email,
+      to: Rails.application.secrets.contact_email
+    }
+  end
+end

--- a/app/views/business_contact_forms/_form.slim
+++ b/app/views/business_contact_forms/_form.slim
@@ -1,0 +1,26 @@
+.container.contact
+  h1.p-3
+    = t('.title')
+  .row.justify-content-center
+    .col-md-8.col-11
+      = simple_form_for @business_contact_form do |f|
+        .row.gx-2
+          .col-lg-6.col-12
+            = f.input :first_name, placeholder: t('mail_form.attributes.business_contact_form.first_name')
+          .col-lg-6.col-12
+            = f.input :last_name, placeholder: t('mail_form.attributes.business_contact_form.last_name')
+        = f.input :company_name, placeholder: t('mail_form.attributes.business_contact_form.company_name')
+        .row.gx-2
+          .col-lg-6.col-12
+            = f.input :email, placeholder: t('mail_form.attributes.business_contact_form.email'), required: true
+          .col-lg-6.col-12
+            = f.input :phone_number, placeholder: t('mail_form.attributes.business_contact_form.phone_number')
+        = f.input :industry, placeholder: t('mail_form.attributes.business_contact_form.industry')
+        fieldset
+          = f.input :message, placeholder: t('mail_form.attributes.business_contact_form.message'), as: :text, input_html: { class: 'mt-3', style: 'height: 240px' }
+          = f.input :attached_file, label: false, as: :file, hint: t('.maximum_attached_file_size')
+        .check-form.form-switch
+          = f.input :need_nda, label: t('.need_nda'), as: :boolean
+        .row
+          .col-md-5.pb-5
+            = f.submit t('.send'), class: 'btn btn-primary btn-block'

--- a/app/views/business_contact_forms/new.slim
+++ b/app/views/business_contact_forms/new.slim
@@ -1,0 +1,3 @@
+- content_for :body_class, 'business-contact-forms'
+.container-fluid.background
+= render 'form'

--- a/app/views/business_contact_forms/show.slim
+++ b/app/views/business_contact_forms/show.slim
@@ -1,0 +1,13 @@
+- content_for :body_class, 'business-contact-forms'
+.container-fluid.background
+.container.contact
+  .row
+    .col.my-5.pt-5.px-3
+      h1.text-center = t('.headline')
+  .row.justify-content-center
+    .col-8
+      = t('.body_html')
+  .row
+    .col.mt-5.pb-5
+      .text-center
+        = link_to t('.back_to_home_page'), root_path, class: 'btn btn-primary'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -95,6 +95,7 @@ search:
 ## Consider these keys used:
 ignore_unused:
   - 'mail_form.attributes.contact_form.{email,message,name,nickname}'
+  - 'business_contact_forms.areas_of_interest.{infrastructure_development,mobile_application_development,other,product_design,web_application_development}'
   - 'mail_form.models.contact_form'
   - 'mail_form.request.{remote_ip,title,user_agent}'
   - 'meta.{description,keywords,site,title,twitter.card,twitter.site}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,16 @@
 ---
 en:
   blog: Blog
+  business_contact_forms:
+    form:
+      maximum_attached_file_size: 'Maximum size file: 20 MB'
+      need_nda: Do you need to get NDA first?
+      send: Send message
+      title: Got a project in mind?
+    show:
+      back_to_home_page: Back to homepage
+      body_html: "<p>\nWe appreciate the trust you've placed in us, and we eagerly embark on analyzing your inquiry. 💼\nThis initial step towards potential collaboration holds particular significance for us.\n</p>\n<p>\nShortly, we will delve into a thorough analysis of your project. 🕒\nKindly exercise patience, as our top priority is to furnish you with a comprehensive and substantive response.\n</p>\n<p>\nIn the meantime, should any questions or ideas arise, do not hesitate to reach out to us. ✉️\nWe are here to assist and clarify any details.\n</p>\n<p>\nOnce again, we appreciate your contact and trust. 🎉\n</p>\n<p>\nBest regards,\nFractal Soft Team 🚀\n</p>\n"
+      headline: "Thank you for your message! 🌟"
   communities:
     index:
       title: Community
@@ -70,6 +80,14 @@ en:
       toggle_navigation: Toggle navigation
   mail_form:
     attributes:
+      business_contact_form:
+        company_name: Company name
+        email: E-mail address
+        first_name: First name
+        industry: Industry
+        last_name: Last name
+        message: Tell us your problem
+        phone_number: Phone number
       contact_form:
         email: E-mail address
         message: Message content

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1,6 +1,16 @@
 ---
 pl:
   blog: Blog
+  business_contact_forms:
+    form:
+      maximum_attached_file_size: 'Maksymalny rozmiar załącznika: 20 MB'
+      need_nda: Czy potrzebujesz najpierw otrzymać NDA?
+      send: Wyślij wiadomość
+      title: Masz jakiś projekt w planach?
+    show:
+      back_to_home_page: Wróć do strony głównej
+      body_html: "<p>\nCenimy zaufanie, jakie nam okazałeś, i z zapałem przystępujemy do analizy Twojego zapytania. 💼\nTen pierwszy krok w kierunku potencjalnej współpracy ma dla nas szczególne znaczenie.\n</p>\n<p>\nJuż wkrótce poświęcimy się dogłębnej analizie Twojego projektu. 🕒\nProsimy o chwilę cierpliwości, gdyż naszym priorytetem jest dostarczenie Ci kompleksowej i merytorycznej odpowiedzi.\n</p>\n<p>\nW międzyczasie, jeśli pojawią się pytania lub pomysły, śmiało się z nami skontaktuj. ✉️\nJesteśmy tu, aby pomóc i doprecyzować wszelkie szczegóły.\n</p>\n<p>\nRaz jeszcze dziękujemy za kontakt i zaufanie. 🎉\n</p>\n<p>\nPozdrawiamy\nZespół Fractal Soft 🚀\n</p>\n"
+      headline: "Dziękujemy za Twoją wiadomość! 🌟"
   communities:
     index:
       title: Społeczność
@@ -70,6 +80,14 @@ pl:
       toggle_navigation: Nawigacja
   mail_form:
     attributes:
+      business_contact_form:
+        company_name: Nazwa firmy
+        email: Adres e-mail
+        first_name: Imię
+        industry: Branża
+        last_name: Nazwisko
+        message: Opowiedz nam o swoim problemie
+        phone_number: Numer telefonu
       contact_form:
         email: Adres e-mail
         message: Treść wiadomości

--- a/config/locales/routes.en.yml
+++ b/config/locales/routes.en.yml
@@ -1,5 +1,6 @@
 en:
   routes:
+    business_contact_forms: business-contact-form
     communities: community
     contact_forms: contact-form
     job_offers: jobs

--- a/config/locales/routes.pl.yml
+++ b/config/locales/routes.pl.yml
@@ -1,5 +1,6 @@
 pl:
   routes:
+    business_contact_forms: biznesowy-formularz-kontaktowy
     communities: spolecznosc
     contact_forms: formularz-kontaktowy
     job_offers: praca

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
 
   localized do
     # resources :projects, only: [:index, :show]
+    resource :business_contact_forms, only: [:show, :new, :create]
     resources :communities, only: [:index, :show]
     resources :contact_forms, only: [:new, :create], path_names: { new: 'new_message' }
     resources :job_offers, only: [:index, :show]

--- a/spec/controllers/business_contact_forms_controller_spec.rb
+++ b/spec/controllers/business_contact_forms_controller_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.describe BusinessContactFormsController do
+  describe 'GET #show' do
+    it 'responds successfully' do
+      get :show, params: { locale: 'en' }
+
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET #new' do
+    it 'successfully renders a new business contact form' do
+      get :new, params: { locale: 'en' }
+
+      aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to render_template('new')
+        expect(assigns(:business_contact_form)).to be_a(BusinessContactForm)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    it 'sends email' do
+      params = {
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'john_doe@example.com'
+      }
+      business_contact_form_double = instance_double(BusinessContactForm)
+      allow(BusinessContactForm).to receive(:new).and_return(business_contact_form_double)
+      allow(business_contact_form_double).to receive(:deliver)
+
+      post :create, params: { business_contact_form: params, locale: 'en' }
+
+      expect(business_contact_form_double).to have_received(:deliver)
+    end
+
+    context 'when English is used' do
+      it 'redirects to the thank you page if the message is sent successfully' do
+        I18n.with_locale(:en) do
+          business_contact_form_double = instance_double(BusinessContactForm)
+          allow(BusinessContactForm).to receive(:new).and_return(business_contact_form_double)
+          allow(business_contact_form_double).to receive(:deliver).and_return(true)
+          params = {
+            first_name: 'John',
+            last_name: 'Doe',
+            email: 'john_doe@example.com'
+          }
+
+          post :create, params: { business_contact_form: params, locale: 'en' }
+
+          expect(response).to redirect_to(business_contact_forms_path(locale: 'en'))
+        end
+      end
+
+      it 'renders new business contact form if sending a message fails' do
+        I18n.with_locale(:en) do
+          business_contact_form_double = instance_double(BusinessContactForm)
+          allow(BusinessContactForm).to receive(:new).and_return(business_contact_form_double)
+          allow(business_contact_form_double).to receive(:deliver).and_return(false)
+          params = {
+            first_name: 'John',
+            last_name: 'Doe',
+            email: 'john_doe@example.com'
+          }
+
+          post :create, params: { business_contact_form: params, locale: 'en' }
+
+          aggregate_failures do
+            expect(response).to be_successful
+            expect(response).to render_template('new')
+          end
+        end
+      end
+    end
+
+    context 'when Polish is used' do
+      it 'redirects to the thank you page if the message is sent successfully' do
+        I18n.with_locale(:pl) do
+          business_contact_form_double = instance_double(BusinessContactForm)
+          allow(BusinessContactForm).to receive(:new).and_return(business_contact_form_double)
+          allow(business_contact_form_double).to receive(:deliver).and_return(true)
+          params = {
+            first_name: 'John',
+            last_name: 'Doe',
+            email: 'john_doe@example.com'
+          }
+
+          post :create, params: { business_contact_form: params, locale: 'pl' }
+
+          expect(response).to redirect_to(business_contact_forms_path(locale: 'pl'))
+        end
+      end
+
+      it 'renders new business contact form if sending a message fails' do
+        I18n.with_locale(:pl) do
+          business_contact_form_double = instance_double(BusinessContactForm)
+          allow(BusinessContactForm).to receive(:new).and_return(business_contact_form_double)
+          allow(business_contact_form_double).to receive(:deliver).and_return(false)
+          params = {
+            first_name: 'John',
+            last_name: 'Doe',
+            email: 'john_doe@example.com'
+          }
+
+          post :create, params: { business_contact_form: params, locale: 'pl' }
+
+          aggregate_failures do
+            expect(response).to be_successful
+            expect(response).to render_template('new')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/business_contact_form_spec.rb
+++ b/spec/models/business_contact_form_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe BusinessContactForm do
+  describe 'validation' do
+    it 'is not valid if the first name is missing' do
+      params = {
+        first_name: '',
+        email: 'john_doe@example.com'
+      }
+      business_contact_form = described_class.new(params)
+
+      expect(business_contact_form).not_to be_valid
+    end
+
+    it 'is not valid if the email address is missing' do
+      params = {
+        first_name: 'John',
+        email: ''
+      }
+      business_contact_form = described_class.new(params)
+
+      expect(business_contact_form).not_to be_valid
+    end
+
+    it 'is valid with required first name and email address' do
+      params = {
+        first_name: 'John',
+        email: 'john_doe@example.com'
+      }
+      business_contact_form = described_class.new(params)
+
+      expect(business_contact_form).to be_valid
+    end
+  end
+end

--- a/spec/routing/business_contact_forms_routing_spec.rb
+++ b/spec/routing/business_contact_forms_routing_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe BusinessContactFormsController do
+  describe 'routing' do
+    context 'when using English' do
+      it 'returns route to #new' do
+        expect(get('/business-contact-form/new')).to route_to(
+          controller: 'business_contact_forms',
+          action: 'new',
+          locale: 'en'
+        )
+      end
+
+      it 'returns route to #create' do
+        expect(post('/business-contact-form')).to route_to(
+          controller: 'business_contact_forms',
+          action: 'create',
+          locale: 'en'
+        )
+      end
+
+      it 'returns route to #show' do
+        expect(get('/business-contact-form')).to route_to(
+          controller: 'business_contact_forms',
+          action: 'show',
+          locale: 'en'
+        )
+      end
+    end
+
+    context 'when using Polish' do
+      it 'returns route to #new' do
+        expect(get('/pl/biznesowy-formularz-kontaktowy/new')).to route_to(
+          controller: 'business_contact_forms',
+          action: 'new',
+          locale: 'pl'
+        )
+      end
+
+      it 'returns route to #create' do
+        expect(post('/pl/biznesowy-formularz-kontaktowy')).to route_to(
+          controller: 'business_contact_forms',
+          action: 'create',
+          locale: 'pl'
+        )
+      end
+
+      it 'returns route to #show' do
+        expect(get('/pl/biznesowy-formularz-kontaktowy')).to route_to(
+          controller: 'business_contact_forms',
+          action: 'show',
+          locale: 'pl'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Pull Request Summary

We are in the process of creating pages about industries where programmers can help.
With these pages we want to relate some call to action, among other things ability to contact with us about cooperation.
The contact form for cooperation needs more information than ordinary contact form.
The client must have possibility to present area of problem and scope of assistance he wants from us.

## Description of the Changes

I have prepared a separate contact form that is more detailed.

## Feedback

N/A

## UI Changes

![business-contact-form-new](https://github.com/fractalsoft/fractalsoft.org/assets/76939215/95490bd6-1d8d-4477-85f1-fe9b6d76bb54)

![business-contact-form-thank-you](https://github.com/fractalsoft/fractalsoft.org/assets/76939215/b1e15093-170b-4570-a4d3-9a1bcf028bcc)
