### PR TITLE
Fix Github action workflow for tests

### DIFF
--- a/.github/workflows/ruby_tests.yaml
+++ b/.github/workflows/ruby_tests.yaml
@@ -28,6 +28,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Download system package lists
+        run: sudo apt-get update
+      - name: Install system dependencies
+        run: sudo apt-get install -y --no-install-recommends libvips42
+        shell: bash
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -38,10 +43,14 @@ jobs:
           gem install bundler
           bundle install --jobs 4 --retry 3
       - name: Setup database
+        env:
+          RAILS_ENV: test
         run: |
           cp config/database.ci.yml config/database.yml
           bundle exec rails db:create
           bundle exec rails db:schema:load
       - name: Run tests
+        env:
+          RAILS_ENV: test
         run:
           bundle exec rspec spec


### PR DESCRIPTION
## Pull Request Summary

I added a github action workflow for ruby tests, but not everything is going right.
While running the ruby tests action I get an error and this workflow fails.
The problems are related to setting up database in correct environment and running specific test which model was dependent on Carrieview::Vips and libvips library.

## Description of the Changes

Setting up a test environment for setting up the database and running tests, and adding a step to install system dependencies in the workflow solved the problems. 

## Feedback

N/A

## UI Changes

N/A
