### PR TITLE
Show only published people

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,7 +291,7 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    importmap-rails (2.0.0)
+    importmap-rails (2.0.1)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)

--- a/app/facades/people_facade.rb
+++ b/app/facades/people_facade.rb
@@ -2,6 +2,6 @@
 
 class PeopleFacade
   def self.list
-    Person.order(:full_name).includes(:translations).all.decorate
+    Person.order(:full_name).includes(:translations).published.decorate
   end
 end

--- a/db/seeds/team/ania.rb
+++ b/db/seeds/team/ania.rb
@@ -8,6 +8,7 @@ ania.assign_attributes(
   image: 'team/ania.jpg',
   last_name: 'Bargieł',
   position: 'adept of programming',
+  published: true,
   skills: %(
     Backend Development, Deployment, Teamwork, GDPR knowledge,
     User Technical Support, Willingness to learn, Logical thinking

--- a/db/seeds/team/lisu.rb
+++ b/db/seeds/team/lisu.rb
@@ -10,6 +10,7 @@ lisu.assign_attributes(
   last_name: 'Lisowski',
   linkedin: 'glisowski91',
   position: 'developer',
+  published: true,
   skills: %(Backend & Frondend Development, Application Architecture, API Design, Refactoring, Visualization)
 )
 

--- a/db/seeds/team/torrocus.rb
+++ b/db/seeds/team/torrocus.rb
@@ -12,6 +12,7 @@ torrocus.assign_attributes(
   last_name: 'Malaszkiewicz',
   linkedin: 'torrocus',
   position: 'developer',
+  published: true,
   skills: %(
             Backend & Frontend Development, Deployment, Teamwork, Leadership, Refactoring, TDD,
             Agile, Team Building, Linux Server Administration, Remote Work, Product Development

--- a/db/seeds/team/womanonrails.rb
+++ b/db/seeds/team/womanonrails.rb
@@ -13,6 +13,7 @@ womanonrails.assign_attributes(
   linkedin: 'womanonrails',
   nickname: 'womanonrails',
   position: 'developer',
+  published: true,
   skills: %(Backend & Frontend Development, Refactoring, TDD, Agile, Scrum, Teamwork, SOA, Remote Work),
   twitter: 'womanonrails',
   vimeo: 'womanonrails'

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -71,4 +71,16 @@ RSpec.describe Person do
       expect(person.skill_list).to be_empty
     end
   end
+
+  describe '.published' do
+    it 'returns only published persons' do
+      published_person = create(:person, published: true)
+      unpublished_person = create(:person, published: false)
+
+      aggregate_failures do
+        expect(described_class.published).to include(published_person)
+        expect(described_class.published).not_to include(unpublished_person)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Pull Request Summary

A minor change that makes us only display a team member if they have their published column set to true.

## Feedback

I don't know why we missed this earlier and didn't use `published` scope.

## UI Changes

The view hasn't changed. For now it's the same.
